### PR TITLE
Rename nc coords flag

### DIFF
--- a/hazard_workflow.cwl
+++ b/hazard_workflow.cwl
@@ -43,7 +43,7 @@ $graph:
       store:
         type: string
         default: "./indicator"
-      write_xarray_compatible_zarr:
+      store_netcdf_coords:
         type: boolean
         default: false
       dask_cluster_kwargs:
@@ -73,7 +73,7 @@ $graph:
           window_years: window_years
           indicator: indicator
           store: store
-          write_xarray_compatible_zarr: write_xarray_compatible_zarr
+          store_netcdf_coords: store_netcdf_coords
           dask_cluster_kwargs: dask_cluster_kwargs
         out:
           - indicator-results
@@ -124,7 +124,7 @@ $graph:
         type: string
       store:
         type: string
-      write_xarray_compatible_zarr:
+      store_netcdf_coords:
         type: boolean
       dask_cluster_kwargs:
         type: string
@@ -159,7 +159,7 @@ $graph:
         valueFrom: $(inputs.central_year_historical)
       - prefix: --window_years
         valueFrom: $(inputs.window_years)
-      - prefix: --write_xarray_compatible_zarr
-        valueFrom: $(inputs.write_xarray_compatible_zarr)
+      - prefix: --store_netcdf_coords
+        valueFrom: $(inputs.store_netcdf_coords)
       - prefix: --dask_cluster_kwargs
         valueFrom: $(inputs.dask_cluster_kwargs)

--- a/hazard_workflow_input_example.yml
+++ b/hazard_workflow_input_example.yml
@@ -1,4 +1,4 @@
-write_xarray_compatible_zarr: false  # type 'boolean'
+store_netcdf_coords: false  # type 'boolean'
 window_years: 0  # type 'int'
 threshold_temperature: 0.1  # type 'float'
 threshold_list: "[]"  # default value of type 'string'.

--- a/notebooks/ukcp18_hazard_DaysTasAboveIndicator.ipynb
+++ b/notebooks/ukcp18_hazard_DaysTasAboveIndicator.ipynb
@@ -139,7 +139,7 @@
     "# Just store stuff locally as it's easier\n",
     "test_output_dir = Path(\"./src/test/test_output\")\n",
     "store = zarr.DirectoryStore(test_output_dir / \"hazard\" / \"hazard.zarr\")\n",
-    "target = OscZarr(store=store, write_xarray_compatible_zarr=True)\n",
+    "target = OscZarr(store=store, store_netcdf_coords=True)\n",
     "\n",
     "model = DaysTasAboveIndicator(\n",
     "    threshold_temps_c=[15],\n",

--- a/src/hazard/cli.py
+++ b/src/hazard/cli.py
@@ -18,7 +18,7 @@ def days_tas_above_indicator(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    write_xarray_compatible_zarr: Optional[bool] = False,
+    store_netcdf_coords: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs,  # To allow for extra parameters to the CLI, due to how CWL will provide all input parameters
 ):
@@ -34,7 +34,7 @@ def days_tas_above_indicator(
         bucket,
         prefix,
         store,
-        write_xarray_compatible_zarr,
+        store_netcdf_coords,
         dask_cluster_kwargs,
     )
 
@@ -51,7 +51,7 @@ def degree_days_indicator(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    write_xarray_compatible_zarr: Optional[bool] = False,
+    store_netcdf_coords: bool = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
     **kwargs,  # To allow for extra parameters to the CLI, due to how CWL will provide all input parameters
 ):
@@ -67,7 +67,7 @@ def degree_days_indicator(
         bucket,
         prefix,
         store,
-        write_xarray_compatible_zarr,
+        store_netcdf_coords,
         dask_cluster_kwargs,
     )
 

--- a/src/hazard/services.py
+++ b/src/hazard/services.py
@@ -28,7 +28,7 @@ def days_tas_above_indicator(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    write_xarray_compatible_zarr: Optional[bool] = False,
+    store_netcdf_coords: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ):
     """
@@ -40,7 +40,7 @@ def days_tas_above_indicator(
     """
 
     docs_store, target, client = setup(
-        bucket, prefix, store, write_xarray_compatible_zarr, dask_cluster_kwargs
+        bucket, prefix, store, store_netcdf_coords, dask_cluster_kwargs
     )
 
     source_dataset_kwargs = (
@@ -75,7 +75,7 @@ def degree_days_indicator(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    write_xarray_compatible_zarr: Optional[bool] = False,
+    store_netcdf_coords: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ):
     """
@@ -87,7 +87,7 @@ def degree_days_indicator(
     """
 
     docs_store, target, client = setup(
-        bucket, prefix, store, write_xarray_compatible_zarr, dask_cluster_kwargs
+        bucket, prefix, store, store_netcdf_coords, dask_cluster_kwargs
     )
 
     source_dataset_kwargs = (
@@ -114,17 +114,16 @@ def setup(
     bucket: Optional[str] = None,
     prefix: Optional[str] = None,
     store: Optional[str] = None,
-    write_xarray_compatible_zarr: Optional[bool] = False,
+    store_netcdf_coords: Optional[bool] = False,
     dask_cluster_kwargs: Optional[Dict[str, Any]] = None,
 ) -> Tuple[DocStore, OscZarr, Client]:
     """
     initialize output store, docs store and local dask client
     """
-
     if store is not None:
         docs_store = DocStore(fs=LocalFileSystem(), local_path=store)
         target = OscZarr(
-            store=store, write_xarray_compatible_zarr=write_xarray_compatible_zarr
+            store=store, store_netcdf_coords=store_netcdf_coords
         )
     else:
         if bucket is None or prefix is None:
@@ -136,7 +135,7 @@ def setup(
             target = OscZarr(
                 bucket=bucket,
                 prefix=prefix,
-                write_xarray_compatible_zarr=write_xarray_compatible_zarr,
+                store_netcdf_coords=store_netcdf_coords,
             )
 
     dask_cluster_kwargs = dask_cluster_kwargs or {}

--- a/src/hazard/sources/osc_zarr.py
+++ b/src/hazard/sources/osc_zarr.py
@@ -29,7 +29,7 @@ class OscZarr(ReadWriteDataArray):
         prefix: str = "hazard",
         s3: Optional[s3fs.S3File] = None,
         store: Optional[Any] = None,
-        write_xarray_compatible_zarr: Optional[bool] = False,
+        store_netcdf_coords: Optional[bool] = False,
     ):
         """For reading and writing to OSC Climate Zarr storage.
         If store is provided this is used, otherwise if S3File is provided, this is used.
@@ -40,7 +40,7 @@ class OscZarr(ReadWriteDataArray):
             prefix: S3 bucket item prefix
             s3: S3File to use if present and if store not provided.
             store: If provided, Zarr will use this store.
-            write_xarray_compatible_zarr: If true, an xarray compatible zarr
+            store_netcdf_coords: If true, an xarray compatible zarr
              will be created alongside the default zarr output
         """
         if store is None:
@@ -61,7 +61,7 @@ class OscZarr(ReadWriteDataArray):
 
         self.root = zarr.group(store=store)
 
-        self.write_xarray_compatible_zarr = write_xarray_compatible_zarr
+        self.store_netcdf_coords = store_netcdf_coords
 
     def create_empty(
         self,
@@ -151,7 +151,7 @@ class OscZarr(ReadWriteDataArray):
         chunks: Optional[List[int]] = None,
         spatial_coords: Optional[bool] = True,
     ):
-        if self.write_xarray_compatible_zarr and spatial_coords:
+        if self.store_netcdf_coords and spatial_coords:
             # In this mode, the xarray is written to path including NetCDF-style co-ordinates.
             # The Zarr array containing the hazard indicator will be in path/indicator.
             self.write_data_array(path, da)

--- a/tests/test_onboarding.py
+++ b/tests/test_onboarding.py
@@ -362,7 +362,7 @@ def test_onboard_flopros(test_output_dir):
     source = FLOPROSFloodStandardOfProtectionSource(source_path)
     model = FLOPROSFloodStandardOfProtection()
     store = zarr.DirectoryStore(os.path.join(test_output_dir, "hazard", "hazard.zarr"))
-    target = OscZarr(store=store, write_xarray_compatible_zarr=True)
+    target = OscZarr(store=store, store_netcdf_coords=True)
     model.run_all(source, target)
     model.create_maps(target, target)
 

--- a/tests/test_utilities.py
+++ b/tests/test_utilities.py
@@ -54,7 +54,7 @@ def test_xarray_write_net_cdf_coords(test_output_dir):  # noqa: F811
     store = zarr.DirectoryStore(os.path.join(test_output_dir, "hazard", "hazard.zarr"))
     # to write to the dev bucket, use simply
     # target = OscZarr()
-    target = OscZarr(store=store, write_xarray_compatible_zarr=True)
+    target = OscZarr(store=store, store_netcdf_coords=True)
     target.write("test/test_netcdf_coords/sop", da, spatial_coords=True)
 
     z = target.read_zarr("test/test_netcdf_coords/sop/indicator")


### PR DESCRIPTION
This resolves the inconsistency between the internal naming and the CLI flag for writing CF compliant Zarr.

Just a suggestion in the context of https://github.com/os-climate/hazard/pull/154